### PR TITLE
fix: DraftEditor crashes in Safari when IME composition committed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes to Draft.js will be documented in this file.
 
 Changes to `src` are live in production on facebook.com at the time of release.
 
+## 0.11.8-rc.1 (Jun 26th, 2021)
+
+### Changed
+* [[`5dfe40d3d4`](https://github.com/twreporter/draft-js/commit/5dfe40d3d4)] - **fix**: add key prop to child component rather than the block (Tai-Jiun Fang)
+
 ## 0.11.8-rc.0 (Jun 10th, 2021)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@twreporter/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.8-rc.0",
+  "version": "0.11.8-rc.1",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorContents-core.react.js
+++ b/src/component/contents/DraftEditorContents-core.react.js
@@ -192,7 +192,6 @@ class DraftEditorContents extends React.Component<Props> {
         preventScroll,
         selection,
         tree: editorState.getBlockTree(key),
-        key: `${key}-${blockKeyMap.get(key) || '0'}`,
       };
 
       const configForType =
@@ -230,8 +229,9 @@ class DraftEditorContents extends React.Component<Props> {
         'data-block': true,
         'data-editor': editorKey,
         'data-offset-key': offsetKey,
-        key,
+        key: `${key}-${blockKeyMap.get(key) || '0'}` ,
       };
+
       if (customEditable !== undefined) {
         childProps = {
           ...childProps,


### PR DESCRIPTION
#### Summary

When typing using IME at the end of a composition, draft-js will do
a full rerender. Which is done by changing the key of DraftEditor component.
If we change the key of a react component, the component itself
will not remount, but any children inside this component will do.
Therefore, children are unmounted and mounted again, which causes editor
crash issue in Safari. Since React reconciliation fail to diff previous DOM
and current DOM due to some of them are considered as 'not-existing'
which can not be removed by the reconsiliation process.

Since this patch, key of existing block won't change hence its children won't remount.

#### Test Plan
Open a file in example folder (e.g. [media.html](https://github.com/twreporter/draft-js/blob/master/examples/draft-0-10-0/media/media.html)).
Make sure the draft editor won't crash after a IME composition is committed, especially in Safari.